### PR TITLE
feat: make `coreHeightCreatedAt` optional

### DIFF
--- a/schema/dashpay.schema.json
+++ b/schema/dashpay.schema.json
@@ -211,8 +211,7 @@
       "encryptedPublicKey",
       "senderKeyIndex",
       "recipientKeyIndex",
-      "accountReference",
-      "coreHeightCreatedAt"
+      "accountReference"
     ],
     "additionalProperties": false
   }

--- a/test/unit/schema.spec.js
+++ b/test/unit/schema.spec.js
@@ -709,7 +709,6 @@ describe('Dashpay Contract', () => {
       });
 
       describe('coreHeightCreatedAt', () => {
-
         it('should not be less than 1', async () => {
           contactRequestData.coreHeightCreatedAt = -1;
 

--- a/test/unit/schema.spec.js
+++ b/test/unit/schema.spec.js
@@ -709,22 +709,6 @@ describe('Dashpay Contract', () => {
       });
 
       describe('coreHeightCreatedAt', () => {
-        it('should be defined', async () => {
-          delete contactRequestData.coreHeightCreatedAt;
-
-          try {
-            dpp.document.create(contract, identityId, 'contactRequest', contactRequestData);
-
-            expect.fail('should throw error');
-          } catch (e) {
-            expect(e.name).to.equal('InvalidDocumentError');
-            expect(e.errors).to.have.a.lengthOf(1);
-            const [error] = e.errors;
-            expect(error.name).to.equal('JsonSchemaError');
-            expect(error.keyword).to.equal('required');
-            expect(error.params.missingProperty).to.equal('coreHeightCreatedAt');
-          }
-        });
 
         it('should not be less than 1', async () => {
           contactRequestData.coreHeightCreatedAt = -1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
with `coreHeightCreatedAt` as a requirement, we found in with v0.17 that this put a constraint on accepting or sending contact requests in the UI in that the Blockchain must be fully synced.  `coreHeightCreatedAt` was being validated against a block height window in a similar way as `createdAt`

The purpose of this field is to set a block height for a contact request that can be used later to improve the synchronization of transactions with respect to a particular contact.  The idea was to support a partial blockchain rescan for a particular set of keys, rather than starting such a scan from the wallet creation date for all addresses/keys.

The field was still left in as optional, though no further work was done with this field this year.

## What was done?
<!--- Describe your changes in detail -->
Removed one field from the required list.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested with v17 and v18 on Testnet and Palinka with respect to creating contactRequests documents.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
